### PR TITLE
add missing qet_directory files in new element folders

### DIFF
--- a/elements/10_electric/20_manufacturers_articles/johson_controls/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/johson_controls/qet_directory
@@ -1,0 +1,5 @@
+<qet-directory>
+    <names>
+        <name lang="en">Johson Controls</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/phoenix_contact/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/phoenix_contact/qet_directory
@@ -1,0 +1,5 @@
+<qet-directory>
+    <names>
+        <name lang="en">Phoenix Contact</name>
+    </names>
+</qet-directory>

--- a/elements/10_electric/20_manufacturers_articles/sofrel/qet_directory
+++ b/elements/10_electric/20_manufacturers_articles/sofrel/qet_directory
@@ -1,0 +1,5 @@
+<qet-directory>
+    <names>
+        <name lang="en">Sofrel</name>
+    </names>
+</qet-directory>


### PR DESCRIPTION
 add missing qet_directory files in new element folders created by @kamikazzyyyy in order to have a folder name displayed in collection explorer, close #15 